### PR TITLE
Fix name of the mapped beans in the circuit form and remove extraneous

### DIFF
--- a/src/main/java/AFPA/CDA03/demo/appliAgence/controllers/AffichController.java
+++ b/src/main/java/AFPA/CDA03/demo/appliAgence/controllers/AffichController.java
@@ -110,9 +110,6 @@ public class AffichController implements WebMvcConfigurer
    @GetMapping("/circuits/ajout")
     public String create( ModelMap params, Circuits circuit)
     {
-       Circuits c = new Circuits();
-       params.put("circuit", c );
-       
        return "ajoutCircuit";
     }
     @PostMapping("/circuits/ajout")
@@ -123,7 +120,7 @@ public class AffichController implements WebMvcConfigurer
         if (bindingResult.hasErrors()) {
             return "ajoutCircuit";
         }
-       // Circuits circuit = new Circuits(0, nom, pays);
+
         CircuitsData.save(circuit);
         this.findAll(params);
         return "listeCircuits";	

--- a/src/main/resources/templates/ajoutCircuit.html
+++ b/src/main/resources/templates/ajoutCircuit.html
@@ -55,7 +55,7 @@ and open the template in the editor.
     <body>
        <h3>Ajout d'un circuit</h3>
         <p class='rouge'><span th:text="${message}"></span></p>   
-        <form action="#" th:action="@{/circuits/ajout}"  th:object="${circuit}" method="post">
+        <form action="#" th:action="@{/circuits/ajout}"  th:object="${circuits}" method="post">
 	<table class="table">
          
 	<tr>


### PR DESCRIPTION
J'ai trouvé !
Apparement, le nom de l'objet mappé avec le form dans "th:object" ne doit pas correspondre au nom de l'argument du controller, mais à son *type*.

Dans ton cas, le type s'appelle, pour une raison ou pour une autre, "Circuits", avec un '*s*' :D

Je n'ai pas trouvé de référence à ce détail dans la doc de Thymleaf, mais ça marche ...

Voilà voilà :)